### PR TITLE
CORE-9169 Add permanent_id_request_move_error template.

### DIFF
--- a/conf/permanent_id_request_move_error.st
+++ b/conf/permanent_id_request_move_error.st
@@ -1,0 +1,3 @@
+$path$ could not be moved to the $dest$ folder in a request made by $username$ in the $environment$ environment.
+
+$error_message$


### PR DESCRIPTION
This PR will add a `permanent_id_request_move_error` template for notifying data admins about errors when attempting to move DOI Request data.