### PR TITLE
CORE-331 Update permanent_id_request_complete message.

### DIFF
--- a/conf/permanent_id_request_complete.st
+++ b/conf/permanent_id_request_complete.st
@@ -1,5 +1,7 @@
 The $request_type$ Permanent ID has been created for the
 $path$
 data set, which has been published in the $environment$ environment.
-See below for the identifiers created by the EZID API request:
+See below for the identifier(s) created:
 $identifiers$
+
+The dataset is available via its landing page at https://doi.org/$doi$.


### PR DESCRIPTION
This PR will update the `permanent_id_request_complete` message (sent to DOI curators) to include the DOI's landing page link and to remove an obsolete reference to "EZID API".